### PR TITLE
Fixes Amazon Linux 2 repository configuration

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,7 +39,11 @@ class zabbix::repo (
         $majorrelease = '6'
       }
       'Amazon'        : {
-        $majorrelease = '6'
+        if $facts['os']['release']['major'] == '2' {
+          $majorrelease = '7'
+        } else {
+          $majorrelease = '6'
+        }
       }
       'oraclelinux' : {
         $majorrelease = $facts['os']['release']['major']


### PR DESCRIPTION
#### Pull Request (PR) description
When Amazon Linux major version is "2", uses EPEL 7 repository

#### This Pull Request (PR) fixes the following issues
Fixes #597
